### PR TITLE
Added new better solution for simulating no network connection

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -2,6 +2,10 @@ import '@testing-library/jest-native/extend-expect'
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock'
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js'
 
+window.setInterval = (promise, time) => {
+  return promise()
+}
+
 //react-hook-form
 global.window = {}
 global.window = global
@@ -15,6 +19,7 @@ jest.mock('react-native-keyboard-aware-scroll-view', () => {
 })
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper')
 
+jest.mock('./src/helpers/axiosHelper')
 jest.mock('./src/helpers/geolocationHelper')
 jest.mock('./src/helpers/sentry')
 jest.mock('./src/services/atlasService')
@@ -24,6 +29,6 @@ jest.mock('./src/services/formPermissionService')
 jest.mock('./src/services/imageService')
 jest.mock('./src/services/localityService')
 jest.mock('./src/services/loggerService')
-jest.mock('./src/services/userService')
+//jest.mock('./src/services/userService')
 jest.mock('./src/services/versionService')
 jest.mock('./src/services/zoneService')

--- a/src/helpers/__mocks__/axiosHelper.ts
+++ b/src/helpers/__mocks__/axiosHelper.ts
@@ -1,0 +1,93 @@
+import { getLoginUrl, getUserUrl, personTokenUrl, pollLoginUrl } from "../../config/urls"
+import storageService from "../../services/storageService"
+
+const getLoginUrlMockData = {
+  'loginURL': 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login?target=KE.1141&redirectMethod=POST&next=%2F%3FtmpToken%3Dtmp_JuVT28QfBI6GTkpPOCfSnBZvAzZXzQXxK0X2dJoY6QY84ODB',
+  'tmpToken': 'tmp_JuVT28QfBI6GTkpPOCfSnBZvAzZXzQXxK0X2dJoY6QY84ODB',
+}
+
+const getUserUrlMockData = {
+  '@context': 'http://schema.laji.fi/context/person-en.jsonld',
+  'defaultLanguage': 'fi',
+  'emailAddress': 'test.testman@testmail.com',
+  'fullName': 'Test Testman',
+  'group': 'LUOMUS',
+  'id': 'MA.1',
+  'role': [
+    'MA.admin',
+  ]
+}
+
+const getUserUrlMockDataWithProfile = {
+  '@context': 'http://schema.laji.fi/context/profile.jsonld',
+  '@type': 'MA.profile',
+  'blocked': [],
+  'friendRequests': [],
+  'friends': [],
+  'id': 'JX.1',
+  'profileKey': 'aVX0EJiEGbEmaIvp',
+  'settings': {
+    'defaultMediaMetadata': {
+      'capturerVerbatim': 'Test Testman',
+      'intellectualOwner': 'Test Testman',
+      'intellectualRights': 'MZ.intellectualRightsCC-BY-4.0',
+    }
+  },
+  'userID': 'MA.1'
+}
+
+const personTokenUrlMockData = {
+  'next': '',
+  'personId': 'MA.1',
+  'target': 'KE.1141',
+}
+
+const pollLoginUrlMockData = {
+  'token': 'Pfk3NA3n6tXMSY6QJMFdWw5w2e8jvlqkiMnpqP0IEJdlgw7m'
+}
+
+// TODO: add more url -> default responses to the functions below
+
+export const get = async (url: string, config?: object) => {
+  if (await storageService.fetch('testingInternetStatus') === 404) {
+    throw {}
+  }
+  console.log('get(' + url + ')')
+  if (url === getLoginUrl) {
+    return { 'data': getLoginUrlMockData }
+  } else if (url.startsWith(getUserUrl)) {
+    if (url.endsWith('/profile')) {
+      return { 'data': getUserUrlMockDataWithProfile }
+    } else {
+      return { 'data': getUserUrlMockData }
+    }
+  } else if (url.startsWith(personTokenUrl)) {
+    return { 'data': personTokenUrlMockData }
+  } else {
+    console.error('WARNING! Axios Mock is not handling url "' + url + '" yet.')
+  }
+}
+  
+export const post = async (url: string, data: any, config?: object) => {
+  if (await storageService.fetch('testingInternetStatus') === 404) {
+    throw {}
+  }
+  console.log('post(' + url + ')')
+  if (url === pollLoginUrl) {
+    return { 'data': pollLoginUrlMockData }
+  } else {
+    console.error('WARNING! Axios Mock is not handling url "' + url + '" yet.')
+  }
+}
+  
+export const axiosDelete = async (url: string, config?: object) => {
+  if (await storageService.fetch('testingInternetStatus') === 404) {
+    throw {}
+  }
+  console.log('delete(' + url + ')')
+  if (url.startsWith(personTokenUrl)) {
+    return {}
+  } else {
+    console.error('WARNING! Axios Mock is not handling url "' + url + '" yet.')
+  }
+}

--- a/src/services/userService.tsx
+++ b/src/services/userService.tsx
@@ -91,7 +91,7 @@ export const checkTokenValidity = async (personToken: string) => {
 
   const result = await get(personTokenUrl + '/' + personToken, { params })
 
-  if (result.data.target !== SOURCE_ID) throw new Error('WRONG SOURCE')
+  if (SOURCE_ID && result.data.target !== SOURCE_ID) throw new Error('WRONG SOURCE')
 
   return result.data
 }


### PR DESCRIPTION
After trying for several days to remove a mocked function and replace it with the original actual implementation, I found this solution to be a much simpler and easier to understand. Basically what it does is:

1. Instead of mocking the service modules, we mock the get/post requests to the webserver. The mocked get() function reads a global variable, in this case "testingInternetStatus" in the async storage, and if the internet status is set to "404" we throw an error just like axios would do:
```
function get() {
    if (testingInternetStatus === 404) {
        throw Error()
    }
    return resultOfValidGetRequest
}
```

2. Your test can now set this variable "testingInternetStatus" to different values in order to get different results from the mock function, see the LoginComponent test for an example.
```
testingInternetStatus = 404
get()
expect(error)

testingInternetStatus = 200
get()
expect(resultOfValidGetRequest)
```

What's left to do now is to refactor the other service mocks into API call mocks and update the tests accordingly.
After that, it should be easy to write new tests which simulate network connection failures.